### PR TITLE
fix checkpoint mark finalization

### DIFF
--- a/src/main/java/org/apache/beam/sdk/io/solace/SolaceCheckpointMark.java
+++ b/src/main/java/org/apache/beam/sdk/io/solace/SolaceCheckpointMark.java
@@ -1,13 +1,15 @@
 package org.apache.beam.sdk.io.solace;
 
 import com.google.common.annotations.VisibleForTesting;
-
 import org.apache.beam.sdk.io.UnboundedSource;
-
-import java.io.IOException;
-import java.io.Serializable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.annotation.Nullable;
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.TimeUnit;
 
 /**
  * Checkpoint for an unbounded Solace source. Consists of the Solace messages waiting to be
@@ -15,38 +17,67 @@ import javax.annotation.Nullable;
  */
 @VisibleForTesting
 class SolaceCheckpointMark implements UnboundedSource.CheckpointMark, Serializable {
-  private static final long serialVersionUID = 42L;
+    private static final long serialVersionUID = 42L;
+    private static final Logger LOG = LoggerFactory.getLogger(SolaceCheckpointMark.class);
 
-  @Nullable private transient UnboundedSolaceReader reader;
-  private String clientName;
+    @Nullable private transient UnboundedSolaceReader reader;
+    private String clientName;
+    private transient BlockingQueue<UnboundedSolaceReader.Message> ackQueue;
 
-  public SolaceCheckpointMark(UnboundedSolaceReader reader, String clientName) {
-    this.reader = reader;
-    this.clientName = clientName;
-  }
+    public SolaceCheckpointMark(UnboundedSolaceReader reader,
+                                String clientName,
+                                BlockingQueue<UnboundedSolaceReader.Message> ackQueue){
+        this.reader = reader;
+        this.clientName = clientName;
+        this.ackQueue = ackQueue;
+      }
 
 
-  @Override
-  public void finalizeCheckpoint() throws IOException {
-    if (reader != null) {
-      reader.ackMessages();
+    @Override
+    public void finalizeCheckpoint() throws IOException{
+        if(reader != null){
+            if (!reader.active.get()){
+                return;
+            }
+            try {
+                while(ackQueue.size()>0){
+                    UnboundedSolaceReader.Message msg = ackQueue.poll(0, TimeUnit.NANOSECONDS);
+
+                    if (msg != null) {
+                        msg.message.ackMessage();
+
+                        // advance watermark
+                        reader.watermark.updateAndGet(min -> {
+                            if (msg.time.getMillis() > min) {
+                                return msg.time.getMillis();
+                            } else {
+                                return min;
+                            }
+                        });
+                    }
+                }
+            }catch(Exception e){
+                LOG.error("Got exception while acking the message: {}", e);
+                throw new IOException(e);
+            }
+        }
     }
-  }
 
-  @Override
-  public boolean equals(Object other) {
-    if (other instanceof SolaceCheckpointMark) {
-      SolaceCheckpointMark that = (SolaceCheckpointMark) other;
-      return this.clientName.equals(that.clientName)
-          && (this.reader == that.reader);
-    } else {
-      return false;
+    @Override
+    public boolean equals(Object other) {
+      if (other instanceof SolaceCheckpointMark) {
+        SolaceCheckpointMark that = (SolaceCheckpointMark) other;
+        return this.clientName.equals(that.clientName)
+            && (this.reader == that.reader);
+      } else {
+        return false;
+      }
     }
-  }
 
-  @Override
-  public int hashCode() {
-    // Effective Java Item 11
-    return clientName.hashCode() * 31 + System.identityHashCode(reader);
-  }    
+    @Override
+    public int hashCode() {
+      // Effective Java Item 11
+      return clientName.hashCode() * 31 + System.identityHashCode(reader);
+    }
+ 
 }

--- a/src/main/java/org/apache/beam/sdk/io/solace/UnboundedSolaceReader.java
+++ b/src/main/java/org/apache/beam/sdk/io/solace/UnboundedSolaceReader.java
@@ -1,48 +1,28 @@
 package org.apache.beam.sdk.io.solace;
 
 import com.google.common.annotations.VisibleForTesting;
-
-import com.solacesystems.jcsmp.BytesXMLMessage;
-import com.solacesystems.jcsmp.CapabilityType;
-import com.solacesystems.jcsmp.ConsumerFlowProperties;
-import com.solacesystems.jcsmp.EndpointProperties;
-import com.solacesystems.jcsmp.FlowReceiver;
-import com.solacesystems.jcsmp.JCSMPException;
-import com.solacesystems.jcsmp.JCSMPFactory;
-import com.solacesystems.jcsmp.JCSMPProperties;
-import com.solacesystems.jcsmp.JCSMPSession;
-import com.solacesystems.jcsmp.JCSMPStreamingPublishEventHandler;
-import com.solacesystems.jcsmp.Queue;
-import com.solacesystems.jcsmp.Requestor;
-import com.solacesystems.jcsmp.Topic;
-import com.solacesystems.jcsmp.XMLMessageProducer;
-
+import com.solacesystems.jcsmp.*;
 import org.apache.beam.sdk.io.UnboundedSource;
-
 import org.joda.time.Instant;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.w3c.dom.Document;
 import org.w3c.dom.Node;
 
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.xpath.XPath;
+import javax.xml.xpath.XPathConstants;
+import javax.xml.xpath.XPathFactory;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-
+import java.io.Serializable;
 import java.util.LinkedList;
 import java.util.NoSuchElementException;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-
-import javax.xml.parsers.DocumentBuilder;
-import javax.xml.parsers.DocumentBuilderFactory;
-
-import javax.xml.xpath.XPath;
-import javax.xml.xpath.XPathConstants;
-import javax.xml.xpath.XPathFactory;
+import java.util.concurrent.atomic.AtomicLong;
 
 
 
@@ -55,7 +35,7 @@ class UnboundedSolaceReader<T> extends UnboundedSource.UnboundedReader<T> {
 
   // The closed state of this {@link UnboundedSolaceReader}. If true, the reader
   // has not yet been closed,
-  private AtomicBoolean active = new AtomicBoolean(true);
+  AtomicBoolean active = new AtomicBoolean(true);
 
   private final UnboundedSolaceSource<T> source;
   private JCSMPSession session;
@@ -69,6 +49,7 @@ class UnboundedSolaceReader<T> extends UnboundedSource.UnboundedReader<T> {
 
   private T current;
   private Instant currentTimestamp;
+  AtomicLong watermark = new AtomicLong(0);
 
   /**
    * Queue to palce advanced messages before {@link #getCheckpointMark()} be
@@ -76,7 +57,7 @@ class UnboundedSolaceReader<T> extends UnboundedSource.UnboundedReader<T> {
    * given {@link UnboundedReader} object will only be accessed by a single thread
    * at once.
    */
-  private java.util.Queue<BytesXMLMessage> wait4cpQueue = new LinkedList<BytesXMLMessage>();
+    private java.util.Queue<Message> wait4cpQueue = new LinkedList<>();
 
   /**
    * Queue to place messages ready to ack, will be accessed by
@@ -182,7 +163,7 @@ class UnboundedSolaceReader<T> extends UnboundedSource.UnboundedReader<T> {
       currentMessageId = msg.getMessageId();
       // onlie client ack mode need to ack message
       if (!isAutoAck) {
-        wait4cpQueue.add(msg);
+        wait4cpQueue.add(new Message(msg, currentTimestamp));
       }
     } catch (Exception ex) {
       throw new IOException(ex);
@@ -207,62 +188,52 @@ class UnboundedSolaceReader<T> extends UnboundedSource.UnboundedReader<T> {
     // TODO: add finally block to close session.
   }
 
-  /**
-   * Direct Runner will call this method on every second.
-   */
-  @Override
-  public Instant getWatermark() {
-    if (current == null) {
-      return Instant.now();
-    }
-    return currentTimestamp;
-  }
-
-  @Override
-  public UnboundedSource.CheckpointMark getCheckpointMark() {
-    // put all messages in wait4cp to safe2ack
-    // and clean the wait4cp queue in the same time
-    try {
-      BytesXMLMessage msg = wait4cpQueue.poll();
-      while (msg != null) {
-        safe2ackQueue.put(msg);
-        msg = wait4cpQueue.poll();
-      }
-    } catch (Exception ex) {
-      LOG.error("Got exception while putting into the blocking queue: {}", ex);
-    }
-
-    SolaceCheckpointMark scm = new SolaceCheckpointMark(this, clientName);
-
-    return scm;
-  }
-
-  /**
-   * Ack all message in the safe2ackQueue called by
-   * {@link SolaceCheckpointMark #finalizeCheckpoint()} It's possible for a
-   * checkpoint to be taken but never finalized So we simply ack all messages
-   * which are read to be ack.
-   */
-  public void ackMessages() throws IOException {
-    LOG.debug("try to ack {} messages with {} Session [{}]", safe2ackQueue.size(), 
-        active.get() ? "active" : "closed",
-        clientName);
-
-    if (!active.get()) {
-      return;
-    }
-    try {
-      while (safe2ackQueue.size() > 0) {
-        BytesXMLMessage msg = safe2ackQueue.poll(0, TimeUnit.NANOSECONDS);
-        if (msg != null) {
-          msg.ackMessage();
+    /**
+     * Direct Runner will call this method on every second
+     */
+    @Override
+    public Instant getWatermark() {
+        if (watermark == null){
+            return new Instant(0);
         }
-      }
-    } catch (Exception ex) {
-      LOG.error("Got exception while acking the message: {}", ex);
-      throw new IOException(ex);
+        return new Instant(watermark.get());
     }
-  }
+
+    static class Message implements Serializable {
+        BytesXMLMessage message;
+        Instant time;
+
+        public Message(BytesXMLMessage message, Instant time) {
+            this.message = message;
+            this.time = time;
+        }
+    }
+
+    @Override
+    public UnboundedSource.CheckpointMark getCheckpointMark() {
+        if (!isAutoAck) {
+            // put all messages in wait4cp to safe2ack
+            // and clean the wait4cp queue in the same time
+            BlockingQueue<Message> ackQueue = new LinkedBlockingQueue<>();
+            try {
+                Message msg = wait4cpQueue.poll();
+                while (msg != null) {
+                    ackQueue.put(msg);
+                    msg = wait4cpQueue.poll();
+                }
+            } catch (Exception e) {
+                LOG.error("Got exception while putting into the blocking queue: {}", e);
+            }
+
+            return new SolaceCheckpointMark(this, clientName, ackQueue);
+        } else {
+            return new UnboundedSource.CheckpointMark() {
+                public void finalizeCheckpoint() throws IOException {
+                    // nothing to do
+                }
+            };
+        }
+    }
 
   @Override
   public T getCurrent() {


### PR DESCRIPTION
we need to ack messages on a per checkpoint mark basis
otherwise, in the case of more than one checkpoint mark being outstanding at any given time,
acknowledgement would mistakenly ack all those checkpoint's messages, even if some may turn out to be never finalized